### PR TITLE
Attempt to fix GH Pages Deploy

### DIFF
--- a/.github/workflows/ghpages-cd.yml
+++ b/.github/workflows/ghpages-cd.yml
@@ -36,3 +36,4 @@ jobs:
         ACCESS_TOKEN: ${{ secrets.GH_PAT }}
         BRANCH: gh-pages
         CNAME: b0tnet.indietasten.net
+        FOLDER: '' # root folder of the repository


### PR DESCRIPTION
The folder environment variable is required for the deployment step. Passing an empty string should result in the root folder of the repository to be deployed. If that doesn't help, the build system must be rewritten to build into a dist folder.